### PR TITLE
34 calendar

### DIFF
--- a/app/server.rb
+++ b/app/server.rb
@@ -7,7 +7,7 @@ class AirBnb < Sinatra::Base
   set :partial_template_engine, :erb
 
   set :static, true
-#  set :public, "public"
+  set :public_folder, "public"
 
   enable :partial_underscores
 

--- a/app/views/layout.erb
+++ b/app/views/layout.erb
@@ -2,7 +2,15 @@
 <html>
   <head>
   <title>AirBnb</title>
-  <link rel="stylesheet" type="text/css" href="<%=url('/style.css')%>"/>
+  <link href="/style.css" rel="stylesheet" type="text/css">
+
+  <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600' rel='stylesheet' type='text/css'>
+  <link href="//netdna.bootstrapcdn.com/font-awesome/3.1.1/css/font-awesome.css" rel="stylesheet">
+
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
+  <link rel="stylesheet"          href="//code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css">
+  <script src="http://code.jquery.com/ui/1.10.2/jquery-ui.js"></script>
+
   </head>
 
   <body>
@@ -12,3 +20,4 @@
     <%=yield%>
   </body>
 </html>
+

--- a/app/views/spaces/space.erb
+++ b/app/views/spaces/space.erb
@@ -11,13 +11,21 @@ Detail view
       }
     }, false);
 
+    <%disable_dates = ["2016-05-19", "2016-05-21"]%>; // for testing
+    var array = <%=disable_dates%>;  // for testing
+    console.log(array);  // for testing
+
     $("#date").datepicker({
-        dateFormat: 'yy-mm-dd',
-        minDate:0, maxDate: 40,
-        onSelect: function(date) {
-          selectedDate = date;
-          alert(date);
-        }
+      beforeShowDay: function(date) {
+        var string = jQuery.datepicker.formatDate('yy-mm-dd', date);
+        return [ array.indexOf(string) == -1 ]
+      },
+      dateFormat: 'yy-mm-dd',
+      minDate:0, maxDate: 40,
+      onSelect: function(date) {
+        selectedDate = date;
+        alert(date);
+      }
       });
 
   </script>

--- a/app/views/spaces/space.erb
+++ b/app/views/spaces/space.erb
@@ -12,7 +12,8 @@ Detail view
     }, false);
 
     $("#date").datepicker({
-        minDate:1, maxDate: 10,
+        dateFormat: 'yy-mm-dd',
+        minDate:0, maxDate: 40,
         onSelect: function(date) {
           selectedDate = date;
           alert(date);

--- a/app/views/spaces/space.erb
+++ b/app/views/spaces/space.erb
@@ -24,7 +24,6 @@ Detail view
       minDate:0, maxDate: 40,
       onSelect: function(date) {
         selectedDate = date;
-        alert(date);
       }
       });
 

--- a/app/views/spaces/space.erb
+++ b/app/views/spaces/space.erb
@@ -1,7 +1,30 @@
+
 Detail view
 <%=@space.name%>
 <form action="/bookings/new" method="post">
-  <input id="date" type="date" name="date" required/>
+  <input id="date" type="date" name="date" class="unstyled" required/>
+
+  <script>
+    date.addEventListener('keydown', function(event) {
+      if (event.keyIdentifier == "Down") {
+        event.preventDefault()
+      }
+    }, false);
+
+    $("#date").datepicker({
+        minDate:1, maxDate: 10,
+        onSelect: function(date) {
+          selectedDate = date;
+          alert(date);
+        }
+      });
+
+  </script>
+
   <input id="space" type="hidden" value="<%=@space.id%>" name="space"/>
   <input id="request" class="button" type="submit" value="Request to book"/>
+
+
+
+
 </form>

--- a/public/style.css
+++ b/public/style.css
@@ -73,3 +73,55 @@ input {
   outline: none;
   text-align: center;
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+.unstyled::-webkit-inner-spin-button,
+.unstyled::-webkit-calendar-picker-indicator {
+    display: none;
+    -webkit-appearance: none;
+}


### PR DESCRIPTION
## closes #34 

some notes:
- Calendar needs to be clicked in order to appear.  To keep the calendar visible at all times brings a whole lot of problems, as all our tests expect an input date and keeping the calendar visible implies to remove that input date and use a div.  We considered it was not worth to go that route.
-  The past is already disabled by default.  Today is kept (as we are booking nights)
-  Specific dates can be disabled in the future, currently we are using an array of dates to test that functionality, (and it works)

We have been naughty: no tests made.... :sheep: 
