### PR TITLE
8 only booking available spaces

### DIFF
--- a/app/controllers/bookings.rb
+++ b/app/controllers/bookings.rb
@@ -3,10 +3,12 @@ class AirBnb < Sinatra::Base
   get "/bookings" do
 
     if current_user
-      @bookings_made = Booking.all(user_id: current_user.id, order: [:date.asc])
+      @bookings_made = Booking.all(user_id: current_user.id,
+                                   order: [:date.asc])
       current_user_spaces = Space.all(user_id: current_user.id)
       current_user_spaces_ids = current_user_spaces.map {|space| space.id}
-      @bookings_received = Booking.all(space_id: current_user_spaces_ids, order: [:date.asc])
+      @bookings_received = Booking.all(space_id: current_user_spaces_ids,
+                                       order: [:date.asc])
       erb :"bookings/index"
     else
       redirect to "/sessions/new"
@@ -14,8 +16,9 @@ class AirBnb < Sinatra::Base
   end
 
   post "/bookings/new" do
-    confirmed_bookings = Booking.all(space_id: params[:space], date: params[:date],status: "confirmed")
-    if confirmed_bookings.length == 0
+    confirmed_bookings = Booking.all(space_id: params[:space],
+                                     date: params[:date],status: "confirmed")
+    if confirmed_bookings.length < 1
       booking = Booking.create(user: current_user,
                                space: Space.first(id: params[:space]),
                                date: params[:date],
@@ -26,7 +29,7 @@ class AirBnb < Sinatra::Base
         redirect to "/bookings"
       end
     else
-      flash[:errors] = ["Booking's already taken"]
+      flash[:errors] = ["Sorry, this date is already taken"]
     end
   end
 

--- a/app/controllers/bookings.rb
+++ b/app/controllers/bookings.rb
@@ -1,11 +1,12 @@
 class AirBnb < Sinatra::Base
 
   get "/bookings" do
+
     if current_user
-      @bookings_made = Booking.all(user_id: current_user.id)
+      @bookings_made = Booking.all(user_id: current_user.id, order: [:date.asc])
       current_user_spaces = Space.all(user_id: current_user.id)
       current_user_spaces_ids = current_user_spaces.map {|space| space.id}
-      @bookings_received = Booking.all(space_id: current_user_spaces_ids)
+      @bookings_received = Booking.all(space_id: current_user_spaces_ids, order: [:date.asc])
       erb :"bookings/index"
     else
       redirect to "/sessions/new"
@@ -13,14 +14,19 @@ class AirBnb < Sinatra::Base
   end
 
   post "/bookings/new" do
-    booking = Booking.create(user: current_user,
-                             space: Space.first(id: params[:space]),
-                             date: params[:date],
-                             status: "requested")
-    if booking.id.nil?
-      flash[:errors] = booking.errors.full_messages
+    confirmed_bookings = Booking.all(space_id: params[:space], date: params[:date],status: "confirmed")
+    if confirmed_bookings.length == 0
+      booking = Booking.create(user: current_user,
+                               space: Space.first(id: params[:space]),
+                               date: params[:date],
+                               status: "requested")
+      if booking.id.nil?
+        flash[:errors] = booking.errors.full_messages
+      else
+        redirect to "/bookings"
+      end
     else
-      redirect to "/bookings"
+      flash[:errors] = ["Booking's already taken"]
     end
   end
 

--- a/app/controllers/spaces.rb
+++ b/app/controllers/spaces.rb
@@ -35,6 +35,8 @@ class AirBnb < Sinatra::Base
   get "/spaces/:id" do
     if current_user
       @space = Space.first(id: params[:id])
+      bookings = Booking.all(space_id: @space.id, status: "confirmed")
+      @bookings_dates = bookings.map {|booking| booking.date.strftime("%Y-%m-%d")}
       erb :"spaces/space"
     else
       redirect to "/sessions/new"

--- a/app/views/bookings/booking.erb
+++ b/app/views/bookings/booking.erb
@@ -10,5 +10,7 @@ Detail view
 <br>
 <p>Other requests for this space</p>
   <% @other_bookings.each do |other_booking| %>
-    <p><%=other_booking.user.name%>
+    <a href="/bookings/<%=other_booking.id%>">
+      <p><%=other_booking.user.name%>
+    </a>
   <%end%>

--- a/app/views/bookings/booking.erb
+++ b/app/views/bookings/booking.erb
@@ -1,5 +1,7 @@
 Detail view
+<br>
 <%=@booking.user.name%>
+<br>
 <%=@booking.space.name%>
 <form action="/bookings/<%=@booking.id%>/confirmed" method="post">
   <input id="confirm" class="button" type="submit" value="Confirm"/>

--- a/app/views/spaces/space.erb
+++ b/app/views/spaces/space.erb
@@ -11,9 +11,8 @@ Detail view
       }
     }, false);
 
-    <%disable_dates = ["2016-05-19", "2016-05-21"]%>; // for testing
-    var array = <%=disable_dates%>;  // for testing
-    console.log(array);  // for testing
+    var array = <%=@bookings_dates%>;  
+    console.log(array);
 
     $("#date").datepicker({
       beforeShowDay: function(date) {

--- a/app/views/spaces/space.erb
+++ b/app/views/spaces/space.erb
@@ -11,8 +11,7 @@ Detail view
       }
     }, false);
 
-    var array = <%=@bookings_dates%>;  
-    console.log(array);
+    var array = <%=@bookings_dates%>;
 
     $("#date").datepicker({
       beforeShowDay: function(date) {
@@ -24,14 +23,10 @@ Detail view
       onSelect: function(date) {
         selectedDate = date;
       }
-      });
+    });
 
   </script>
 
   <input id="space" type="hidden" value="<%=@space.id%>" name="space"/>
   <input id="request" class="button" type="submit" value="Request to book"/>
-
-
-
-
 </form>

--- a/spec/features/create_booking_spec.rb
+++ b/spec/features/create_booking_spec.rb
@@ -27,13 +27,12 @@ feature "create a new booking" do
     click_link "booking#{Booking.first.id}"
     click_button "Confirm"
     logout
-    params = {name: "Sergio",
-              username: "sergio",
-              email: "sergio@gmail.com",
+    params = {name: "Aday",
+              username: "aday",
+              email: "aday@gmail.com",
               password: "my_password",
               password_confirmation: "my_password"}
     sign_up(params)
-    visit "/spaces"
     click_link "space#{Space.first.id}"
     fill_in :date, with: Time.new(2016,5,30)
     expect{click_button "Request to book"}.to change(Booking, :count).by(0)

--- a/spec/features/create_booking_spec.rb
+++ b/spec/features/create_booking_spec.rb
@@ -18,4 +18,25 @@ feature "create a new booking" do
     expect{create_booking(nil)}.to change(Booking, :count).by(0)
   end
 
+  scenario "cannot create booking if unavailable date" do
+    pre_create_booking
+    create_booking
+    logout
+    login
+    visit "/bookings"
+    click_link "booking#{Booking.first.id}"
+    click_button "Confirm"
+    logout
+    params = {name: "Sergio",
+              username: "sergio",
+              email: "sergio@gmail.com",
+              password: "my_password",
+              password_confirmation: "my_password"}
+    sign_up(params)
+    visit "/spaces"
+    click_link "space#{Space.first.id}"
+    fill_in :date, with: Time.new(2016,5,30)
+    expect{click_button "Request to book"}.to change(Booking, :count).by(0)
+  end
+
 end


### PR DESCRIPTION
Closes #8 
1. Sergio and Aday set the fancy calendar up for us, so we just had to swap the disabled_dates array (testing) for the "real" confirmed dates.
2. As requested, 😉 , we also made the bookings appear in chronological order.
3. Also as requested, we made all the bookings in the "Other booking requests" section clickable.

Full marks for Sergio and Aday 💯 for figuring out the fancy calendar stuff (and for sneakily hiding it!) 
And bonus points for Maria for being, once again, the DataMapper queen 👑 

Gracias 
