### PR TITLE
Styling on /bookings page

### DIFF
--- a/app/views/bookings/index.erb
+++ b/app/views/bookings/index.erb
@@ -1,33 +1,45 @@
 <h1>My Bookings</h1>
 
-<div class="tiny_space"></div>
-<div align="left"> Bookings I've made
-  <% @bookings_made.each do |booking| %>
-    <a href="/spaces/<%=booking.space.id%>">
-      <div style="width:75%">
-        <p><%=booking.id%></p>
-        <p><%=booking.date%></p>
-        <p><%=booking.status%></p>
-        <p><%=booking.space.name%></p>
-        <p class="username">by <strong><%=booking.user.name%></strong></p>
-        <div class="tiny_space"></div>
-      </div>
-    </a>
-  <%end%>
-</div>
+<section class ="column bookings_made">
+  <div align="left"> Bookings I've made
+    <% @bookings_made.each do |booking| %>
+      <table class="parent-div">
+        <tr>
+          <td class="ellipsis"><%=booking.date%></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td><%=booking.space.name%></td>
+            <td><a href="/bookings/<%=booking.id%>">...More</a></td>
+        </tr>
+        <tr>
+          <td class="ellipsis"><%=booking.status%></td>
+         <td></td>
+        </tr>
+        <br>
+      </table>
+    <%end%>
+  </div>
+</section>
 
-<div class="tiny_space"></div>
-<div align="right"> Bookings I've receieved
-  <% @bookings_received.each do |booking| %>
-    <a id="booking<%=booking.id%>" href="/bookings/<%=booking.id%>">
-      <div style="width:75%">
-        <p><%=booking.id%></p>
-        <p><%=booking.date%></p>
-        <p><%=booking.status%></p>
-        <p><%=booking.space.name%></p>
-        <p class="username">by <strong><%=booking.user.name%></strong></p>
-        <div class="tiny_space"></div>
-      </div>
-    </a>
-  <%end%>
+<section class ="column bookings_received">
+  <div align="right"> Bookings I've receieved
+    <% @bookings_received.each do |booking| %>
+      <table class="parent-div">
+        <tr>
+          <td class="ellipsis"><%=booking.date%></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td><%=booking.space.name%></td>
+            <td><a id="booking<%=booking.id%>" href="/bookings/<%=booking.id%>">...More</a></td>
+        </tr>
+        <tr>
+          <td class="ellipsis"><%=booking.status%></td>
+          <td></td>
+        </tr>
+        <br>
+      </table>
+    <%end%>
 </div>
+</section>

--- a/app/views/spaces/index.erb
+++ b/app/views/spaces/index.erb
@@ -18,26 +18,19 @@
   <a id="space<%=space.id%>" href="/spaces/<%=space.id%>">
     <div>
       <table class="parent-div">
-        <col width="20%">
-        <col content-align="center" width="60%">
-        <col width="20%">
         <tr>
-          <td class="ellipsis">Name</td>
           <td class="ellipsis"><%=space.name%></td>
           <td></td>
         </tr>
         <tr>
-          <td class="ellipsis">Description</td>
           <td><%=space.description%></td>
           <td>Book</td>
         </tr>
         <tr>
-          <td class="ellipsis">Price</td>
           <td class="ellipsis"><%=space.price%></td>
           <td></td>
         </tr>
         <tr>
-          <td></td>
           <td><p class="username">by <strong><%=space.user.name%></strong> (@<%=space.user.username%>)</p></td>
           <td></td>
         </tr>

--- a/public/style.css
+++ b/public/style.css
@@ -173,7 +173,23 @@ a.button:hover {
 
 
 
+.column {
+ display: inline-block;
+ height: 80vh;
 
+}
+
+.bookings_made {
+ width: 49%;
+ overflow: hidden;
+ position: relative;
+}
+
+.bookings_received {
+ width: 49%;
+ overflow: hidden;
+ position: relative;
+}
 
 
 
@@ -504,40 +520,15 @@ a.button:hover {
 }
 
 
-/*.ellipsis {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-#div2 {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    width: 40em;
-    min-width: 0;
-}
-
-.parent-div {
-    display: flex;
-}
-
-
-table{
-    border: 1px solid black;
-    border-collapse: collapse;
-}
-th, td {
-    padding: 5px;
-}*/
-
-
 table {
     width: 100%;
     border: 1px solid black;
     border-collapse: collapse;
 }
 td {
+    padding-left: 10px;
+    content-align: left;
+    width: 60%;
     max-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -545,10 +536,6 @@ td {
 }
 
 tr td:nth-child(2) { /* I don't think they are 0 based */
-   text-align: center;
-}
-
-tr td:nth-child(3) { /* I don't think they are 0 based */
    text-align: center;
 }
 

--- a/spec/features/view_bookings_spec.rb
+++ b/spec/features/view_bookings_spec.rb
@@ -38,10 +38,8 @@ feature "view booking" do
     logout
     login
     visit "/bookings"
-    expect(page).to have_content "Maria"
-    expect(page).to have_content "Sergio"
-    expect(page).to have_content "Amy's house"
-    expect(page).to have_content "2016-05-30"
+    expect(page).to have_content("Amy's house", count: 2)
+    expect(page).to have_content("2016-05-30", count: 2)
   end
 
   scenario "viewing each booking I've received in more detail" do


### PR DESCRIPTION
Closes #46 

Styling for the booking page...same as the spaces page.

Also updated a test which started failing because we decided not to include the customer name (to make it consistent with the spaces page i.e. three rows) on the Bookings list page. But the detail view will still have the customer name.
